### PR TITLE
Added require('...') support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react", "stage-1"]
+  "presets": ["es2015", "react", "stage-1"],
+  "plugins": ["add-module-exports"]
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/oliviertassinari/serviceworker-webpack-plugin#readme",
   "dependencies": {
-    "babel-plugin-add-module-exports": "^0.2.1",
     "minimatch": "^3.0.2",
     "webpack": "^1.13.1"
   },
@@ -45,6 +44,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.5.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "css-loader": "^0.23.1",
     "eslint": "^3.0.0",
     "eslint-plugin-react": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/oliviertassinari/serviceworker-webpack-plugin#readme",
   "dependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
     "minimatch": "^3.0.2",
     "webpack": "^1.13.1"
   },


### PR DESCRIPTION
## Reason for PR

Compatibility with old, ES5 CommonJS `var X = require('...');` imports.

## Problem

Old style `require('...')` imports will not work as expected with newer Babel versions. Example: 

![screenshot from 2016-07-28 11-19-13](https://cloud.githubusercontent.com/assets/333327/17205805/456f525c-54b5-11e6-96b2-84595d98ae39.png)

The export would be an object containing the `default` property, which in turn references the module, instead of obtaining the module directly. This will work fine in an ES6 environment, but in older, ES5 environments, it would require an extra step. 

Proper import of the module would look like this: 

```javascript

// ES6 / Babel
import ServiceWorkerWebpackPlugin from 'serviceworker-webpack-plugin';

// ES5
var ServiceWorkerWebpackPlugin = require('serviceworker-webpack-plugin').default;

```

## Fix

The **add-module-exports** plugin added to `package.json` and `.babelrc` will add an extra `module.exports = exports['default'];` to the end of each JS file, and would add a compatibility layer (aka. the above require example would not need the extra `.default` in the end). Example: 

![screenshot from 2016-07-28 11-23-35](https://cloud.githubusercontent.com/assets/333327/17205951/f7927af4-54b5-11e6-9e92-5cf30ae899bd.png)

## Conclusion

In the end, the import works as expected in the legacy import style:

![screenshot from 2016-07-28 11-28-25](https://cloud.githubusercontent.com/assets/333327/17206038/70d31d42-54b6-11e6-9312-d6c9d682adf6.png)

Thank you for reading through this. I hope I didn't overdo the description for this PR :)  