### PR TITLE
Add include option - whitelist for matching assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@ Path to the actual service worker implementation.
  - `filename`, *string*, default `'sw.js'`:
 Relative (from the webpack's config `output.path`) output path for emitted script.
  - `excludes`, *array*, default `['**/.*', '**/*.map']`:
-Excludes matches assets from being added to the `serviceWorkerOption.assets` variable.
+Exclude matched assets from being added to the `serviceWorkerOption.assets` variable. (Blacklist)
+ - `includes`, *array*, default `['**/*']`:
+Include matched assets added to the `serviceWorkerOption.assets` variable. (Whitelist)
  - `publicPath`, *string*, default `''`:
-specifies the public URL address of the output files when referenced in a browser.
+Specifies the public URL address of the output files when referenced in a browser.
  - `template`, *function*, default noop:
 This callback function can be used to inject statically generated service worker.
 It's taking a `serviceWorkerOption` argument and must return a promise.

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ export default class ServiceWorkerPlugin {
     this.options = Object.assign({
       publicPath: '',
       excludes: ['**/.*', '**/*.map'],
+      includes: ['**/*'],
       entry: null,
       filename: 'sw.js',
       template: () => Promise.resolve(''),
@@ -137,6 +138,16 @@ export default class ServiceWorkerPlugin {
     if (excludes.length > 0) {
       assets = assets.filter((assetCurrent) => {
         return !excludes.some((glob) => {
+          return minimatch(assetCurrent, glob);
+        });
+      });
+    }
+
+    const includes = this.options.includes;
+
+    if (includes.length > 0) {
+      assets = assets.filter((assetCurrent) => {
+        return includes.some((glob) => {
           return minimatch(assetCurrent, glob);
         });
       });


### PR DESCRIPTION
Rather than blacklisting assets, allow the user to whitelist just the assets required via `include` option