### PR TITLE
Add contextual issuerAssets to serviceWorkerOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ E.g. In our example this object look like:
       './images/header-bg-3ca906.jpg'
     ],
   },
+  chunkAssets: {
+    'main': [
+      './main.256334452761ef349e91.js',
+    ],
+  },
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,6 +122,25 @@ export default class ServiceWorkerPlugin {
   handleEmit(compilation, compiler, callback) {
     const asset = compilation.assets[this.options.filename];
 
+    const jsonStats = compilation.getStats().toJson({
+      hash: false,
+      publicPath: false,
+      assets: false,
+      chunks: false,
+      modules: true,
+      source: false,
+      errorDetails: false,
+      timings: false,
+    });
+    const modules = jsonStats.modules.filter((module) => module.assets.length > 0);
+    const issuerAssets = {};
+    modules.forEach((module) => {
+      if (!issuerAssets[module.issuerName]) {
+        issuerAssets[module.issuerName] = [];
+      }
+      issuerAssets[module.issuerName].push(...module.assets);
+    });
+
     if (!asset) {
       compilation.errors.push(
         new Error('ServiceWorkerPlugin: ServiceWorker entry is not found in output assets'),
@@ -161,6 +180,7 @@ export default class ServiceWorkerPlugin {
 
     const serviceWorkerOption = {
       assets,
+      issuerAssets,
     };
 
     const templatePromise = this.options.template(serviceWorkerOption);

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ export default class ServiceWorkerPlugin {
     const jsonStats = compilation.getStats().toJson({
       hash: false,
       publicPath: false,
-      assets: false,
+      assets: true,
       chunks: false,
       modules: true,
       source: false,
@@ -140,6 +140,7 @@ export default class ServiceWorkerPlugin {
       }
       issuerAssets[module.issuerName].push(...module.assets);
     });
+
 
     if (!asset) {
       compilation.errors.push(
@@ -181,6 +182,7 @@ export default class ServiceWorkerPlugin {
     const serviceWorkerOption = {
       assets,
       issuerAssets,
+      chunkAssets: jsonStats.assetsByChunkName,
     };
 
     const templatePromise = this.options.template(serviceWorkerOption);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -25,6 +25,24 @@ describe('ServiceWorkerPlugin', () => {
           'bar.js': {},
           'foo.js': {},
         },
+        getStats: () => ({
+          toJson: () => ({
+            modules: [
+              {
+                issuerName: './src/header.js',
+                assets: ['images/banner.png'],
+              },
+              {
+                issuerName: './src/header.js',
+                assets: ['images/logo.png'],
+              },
+              {
+                issuerName: './src/footer.js',
+                assets: [],
+              },
+            ],
+          }),
+        }),
       };
 
       return serviceWorkerPlugin
@@ -36,7 +54,13 @@ describe('ServiceWorkerPlugin', () => {
 var serviceWorkerOption = {
   "assets": [
     "/bar.js"
-  ]
+  ],
+  "issuerAssets": {
+    "./src/header.js": [
+      "images/banner.png",
+      "images/logo.png"
+    ]
+  }
 };`));
         });
     });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -27,6 +27,12 @@ describe('ServiceWorkerPlugin', () => {
         },
         getStats: () => ({
           toJson: () => ({
+            assetsByChunkName: {
+              main: [
+                'bar.js',
+                'foo.js',
+              ],
+            },
             modules: [
               {
                 issuerName: './src/header.js',
@@ -59,6 +65,12 @@ var serviceWorkerOption = {
     "./src/header.js": [
       "images/banner.png",
       "images/logo.png"
+    ]
+  },
+  "chunkAssets": {
+    "main": [
+      "bar.js",
+      "foo.js"
     ]
   }
 };`));


### PR DESCRIPTION
Instead of saving an entire application in the cache it is often desirable to only cache key files. To provide more context on loaded files serviceWorkerOption.issuerAssets sorts loaded assets into their module loaders (module.loaderName). This allows us to only load assets from key components (and load the remainder down the path if required).
Note that it doesn't pick up the output from chunks so the main output file will not be included. This could easily be added under a chunksAsset attribute if required. 