### PR TITLE
Don't manually override filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,8 +45,6 @@ export default class ServiceWorkerPlugin {
         assets: serviceWorkerOption.assets,
       }),
     }, options);
-
-    this.options.filename = this.options.filename.replace(/^\//, '');
   }
 
   apply(compiler) {


### PR DESCRIPTION
Overriding user settings is a very bad idea. If someone prepends the filename with a slash, this is usually with right cause. This causes unpredictable behaviour within Webpack. Especially other plugins depending on the asset list like AppCacheWebpackPlugin will trip on this.

Because of this we had the following bug in our appcache.manifest:
```
CACHE MANIFEST
# a5ccd581f3cef1493d76

/statics/browser-compatibility.js
/statics/password-strength-utils.js
/statics/site.js
/statics/browser-compatibility.css
/statics/site.css
statics/service-worker.js

NETWORK:
*
```

Notice the missing slash in front of `statics/service-worker.js`.