### PR TITLE
Fix tapable apply

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,8 +95,9 @@ export default class ServiceWorkerPlugin {
     const childCompiler = compilation.createChildCompiler(COMPILER_NAME, {
       filename: this.options.filename,
     })
-    childCompiler.context = compiler.context
-    childCompiler.apply(new SingleEntryPlugin(compiler.context, this.options.entry))
+
+    const childEntryCompiler = new SingleEntryPlugin(compiler.context, this.options.entry)
+    childEntryCompiler.apply(childCompiler)
 
     // Fix for "Uncaught TypeError: __webpack_require__(...) is not a function"
     // Hot module replacement requires that every child compiler has its own

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -67,6 +67,27 @@ describe('ServiceWorkerPlugin', () => {
     })
   })
 
+  it('should correctly generate a service worker', () => {
+    const options = makeWebpackConfig({
+      filename: '//sw.js',
+    })
+    return webpack(options, (err, stats) => {
+      expect(err).to.equal(null)
+      const { assetsByChunkName, errors, warnings } = stats.toJson()
+      expect(errors).to.have.length(0)
+      expect(warnings).to.have.length(0)
+
+      const swFile = fs
+        .readFileSync(path.join(webpackOutputPath, 'sw.js'), 'utf8')
+        .replace(/\s+/g, ' ')
+
+      // sw.js should reference main.js
+      expect(swFile).to.include('var serviceWorkerOption = { "assets": [ "/main.js" ] }')
+      // sw.js should include the webpack require code
+      expect(swFile).to.include('function __webpack_require__(moduleId)')
+    })
+  })
+
   describe('options: includes', () => {
     it('should allow to have a white list parameter', () => {
       const serviceWorkerPlugin = new ServiceWorkerPlugin({

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,5 @@
 --require babel-register
 --reporter dot
 --recursive
+--throw-deprecation
 src/{,**/}*.spec.js


### PR DESCRIPTION
Fixes #63 

Change the call to `SingleEntryPlugin.apply` to the new way of calling it.

To make sure nothing breaks, I've also added a testcase on the contentes of sw.js.