### PR TITLE
minimize on production mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,7 +187,7 @@ export default class ServiceWorkerPlugin {
       const serviceWorkerOptionInline = JSON.stringify(
         serviceWorkerOption,
         null,
-        this.options.minimize ? 0 : 2
+        (compiler.options.mode === 'production' || this.options.minimize) ? 0 : 2
       )
 
       const source = `


### PR DESCRIPTION
When setting [the webpack mode](https://webpack.js.org/concepts/mode/) to `production` I expected the `serviceWorkerOption` to be minified. After running through the code I noticed this only happens when either the `minimize` option is set or if the `NODE_ENV` is equal to `production`. To adhere to the new webpack configuration property, I think this plugin should also minify when the mode is set to `production`.


- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
  - There are no tests for this part of the code sadly.