### PR TITLE
added typescript definitions for runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "1.0.1",
   "description": "Simplifies creation of a service worker to serve your webpack bundles",
   "main": "lib/index.js",
+  "typings": "types/index.d.ts",  
   "files": [
     "lib",
-    "src"
+    "src",
+    "types"
   ],
   "scripts": {
     "clean": "rimraf ./docs/dist ./lib",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,6 @@
+declare class Runtime {
+    public register(): Promise<ServiceWorkerRegistration>;
+}
+
+declare const serviceworker: Runtime;
+export default serviceworker;


### PR DESCRIPTION
<!--
### What is accomplished by your PR?
The runtime.register function will also compile in typescript projects.

### Is there something controversial in your PR?
My other choice is to write the typescript definition for the plugin inside of my project.

### Link to the Issue
https://github.com/oliviertassinari/serviceworker-webpack-plugin/issues/98

